### PR TITLE
fix: get:url pin corrupts container_client on other tagged instances

### DIFF
--- a/src/blob-store.ts
+++ b/src/blob-store.ts
@@ -367,7 +367,7 @@ async function blob_store(this: any, options: any) {
       let accessUrl = '',
         sasToken = ''
 
-      const containerClient = blob_client.getContainerClient(container)
+      const containerClient = await load_container_client(container)
       const blob = containerClient.getBlobClient(filepath)
 
       const now = new Date()

--- a/src/blob-store.ts
+++ b/src/blob-store.ts
@@ -117,10 +117,6 @@ async function blob_store(this: any, options: any) {
     return container_client
   }
 
-  async function container_check(name: string) {
-    container_client = await load_container_client(name)
-  }
-
   let store = {
     name: 'blob-store',
     save: function (msg: any, reply: any) {
@@ -370,8 +366,6 @@ async function blob_store(this: any, options: any) {
       const expire = msg.expire
       let accessUrl = '',
         sasToken = ''
-
-      await container_check(container)
 
       const containerClient = blob_client.getContainerClient(container)
       const blob = containerClient.getBlobClient(filepath)

--- a/test/blob-store.test.js
+++ b/test/blob-store.test.js
@@ -341,6 +341,73 @@ lab.test('bin-local-customid', async function () {
   })
 })
 
+// Regression test for get:url not corrupting other tagged instances.
+lab.test('get-url-does-not-corrupt-other-tagged-instance', async function () {
+  const blob = {
+    mode: 'local',
+    endpoint: 'http://127.0.0.1:10000/devstoreaccount1',
+  }
+
+  const s0 = Seneca({ legacy: false })
+    .test()
+    .use('promisify')
+    .use('entity', { mem_store: false })
+    .use(
+      { name: 'blob-store$regress_a', init: Plugin },
+      {
+        prefix: '',
+        suffix: '',
+        folder: '',
+        map: { '-/regress/a': '*' },
+        ent: { '-/regress/a': { bin: 'content' } },
+        shared: { Container: 'test-container-regress-a' },
+        blob,
+      }
+    )
+    .use(
+      { name: 'blob-store$regress_b', init: Plugin },
+      {
+        prefix: '',
+        suffix: '',
+        folder: '',
+        map: { '-/regress/b': '*' },
+        ent: { '-/regress/b': { bin: 'content' } },
+        shared: { Container: 'test-container-regress-b' },
+        blob,
+      }
+    )
+
+  await s0.ready()
+
+  // Idempotent: remove any existing test files from both containers.
+  await s0.entity('regress/a').remove$('regress-test.bin')
+  await s0.entity('regress/b').remove$('regress-test.bin')
+
+  const urlRes = await s0.post('cloud:azure,service:store,get:url,kind:upload', {
+    container: 'test-container-regress-a',
+    filepath: 'unrelated.bin',
+    expire: 600,
+  })
+  expect(urlRes.url).exists()
+
+  // Save an entity that belongs to instance B. Before the fix, this could
+  // land in container A instead of container B.
+  const saved = await s0
+    .entity('regress/b')
+    .data$({ content: Buffer.from('instance-b-content') })
+    .save$({ id$: 'regress-test.bin' })
+
+  expect(saved.entity$).equal('-/regress/b')
+
+  const loadedB = await s0.entity('regress/b').load$('regress-test.bin')
+  expect(loadedB).exists()
+  expect(loadedB.content.toString('utf-8')).equal('instance-b-content')
+
+  // Prove it did not (also) land in container A under instance A's own canon.
+  const loadedA = await s0.entity('regress/a').load$('regress-test.bin')
+  expect(loadedA).not.exist()
+})
+
 function makeSeneca(blobopts) {
   return Seneca({ legacy: false })
     .test()


### PR DESCRIPTION
## Summary

Loading two tagged instances of this plugin (one per Azure Blob container, the documented way to use more than one container) and calling `get:url` for one container silently corrupts a different tagged instance's subsequent `save$`/`load$`, pointing it at the wrong container. No error at any point: every individual Azure call succeeds, just against the wrong container.

## Root cause

`getSignedUrl` (the handler for `get:url`) calls `container_check(container)`, which reassigns the `container_client` variable that `save`/`load`/`remove` also use. But `getSignedUrl` never actually uses `container_client` after that call; it builds its own separate client on the next line. So the call does nothing for `get:url` itself, and only has the side effect of leaving `container_client` pointed at the wrong container for later saves and loads.

## Fix

Removes the dead `container_check` call and the now-unused `container_check` function. `getSignedUrl`'s own behavior is unchanged.

## Test

Adds a regression test: load two tagged instances, mint a SAS for container A, save an entity that belongs to instance B, and check it landed in B, not A. This test fails on the code before the fix and passes after.